### PR TITLE
Obscure privacy page contact email from scrapers

### DIFF
--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,3 +1,13 @@
+<script lang="ts">
+// Email encoded as base64 to deter scrapers. Decoded only on click.
+const contactEmailBase64 = 'dGhlb0BjcmFmdHMuc29mdHdhcmU=';
+
+function handleEmailClick() {
+	const email = atob(contactEmailBase64);
+	window.location.href = `mailto:${email}`;
+}
+</script>
+
 <svelte:head>
   <title>Privacy Policy - crafts.software</title>
   <meta
@@ -87,11 +97,12 @@
       <section>
         <h2 class="text-lg font-semibold text-gray-900">Contact</h2>
         <p class="mt-2 leading-relaxed">
-          Questions about this policy or your data? Email
-          <a
-            href="mailto:theo@crafts.software"
-            class="font-medium text-gray-900 underline underline-offset-2 hover:text-gray-600"
-            >theo@crafts.software</a
+          Questions about this policy or your data?
+          <button
+            type="button"
+            onclick={handleEmailClick}
+            class="cursor-pointer font-medium text-gray-900 underline underline-offset-2 hover:text-gray-600"
+            >Email us</button
           >.
         </p>
       </section>


### PR DESCRIPTION
## Summary
- The /privacy page printed theo@crafts.software as plain text in a mailto link, exposed verbatim in the served HTML
- Matches the pattern used across the estate's other SvelteKit sites (landing-template and its forks protect-my-sim, flareclues, untitled-stories, palseer, and gregory.sh): base64-encode the address, decode it with atob() only on click
- The plain address no longer appears in markup or server-rendered output, only the base64 string does

## Test plan
- [x] bun run lint
- [x] bun run check
- [x] bun run build
- [x] grepped the built server output for the plain email, not present

Reopens TSE-364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Privacy page’s contact email interaction to open the user’s email client reliably.
  * Prevented the email address from appearing directly in the rendered page markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->