### PR TITLE
fix(privacy): update contact email to site@crafts.software

### DIFF
--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 // Email encoded as base64 to deter scrapers. Decoded only on click.
-const contactEmailBase64 = 'dGhlb0BjcmFmdHMuc29mdHdhcmU=';
+const contactEmailBase64 = 'c2l0ZUBjcmFmdHMuc29mdHdhcmU=';
 
 function handleEmailClick() {
 	const email = atob(contactEmailBase64);


### PR DESCRIPTION
## Summary
- Update the obscured contact email on /privacy from theo@crafts.software to site@crafts.software
- Only the base64-encoded value changes; the existing scraper-deterrence pattern (base64 + atob in click handler) stays as-is

## Test plan
- [x] `bun run lint` passes
- [x] `bun run check` passes (0 errors, 0 warnings)
- [x] `bun run build` succeeds
- [x] Grepped built output: neither theo@crafts.software nor site@crafts.software appears in plain text; only the new base64 string is present in the client bundle

Linear: TSE-367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the privacy page’s “Email us” contact address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->