### PR TITLE
Add the ICO registration number to the privacy policy (TSE-421)

### DIFF
--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -21,13 +21,14 @@ function handleEmailClick() {
     <h1 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
       Privacy Policy
     </h1>
-    <p class="mt-2 text-sm text-gray-500">Effective date: 20 July 2026</p>
+    <p class="mt-2 text-sm text-gray-500">Effective date: 7 August 2026</p>
 
     <div class="mt-10 space-y-8 text-gray-700">
       <section>
         <h2 class="text-lg font-semibold text-gray-900">Who we are</h2>
         <p class="mt-2 leading-relaxed">
-          This site is run by The Software Engineer LTD, a UK company. This
+          This site is run by The Software Engineer LTD, a UK company. We are
+          registered with the ICO, registration number ZC208439. This
           policy covers crafts.software and its subdomain project sites (for
           example landing pages for individual products or ideas built by
           the company).


### PR DESCRIPTION
The ICO issued registration ZC208439 for The Software Engineer LTD.

Names it in the "Who we are" section of the privacy policy and bumps the effective date to 7 August 2026.

Pairs with the-software-engineer/lanteon#174, which does the same for the Lanteon policy.

TSE-421

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the privacy policy effective date to 7 August 2026.
  * Added the company’s ICO registration number: ZC208439.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->